### PR TITLE
Add Travis-CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+dist: xenial
+
+language: python
+python:
+  - "3.6"
+  - "3.7"
+
+install:
+  - pip install --upgrade -r requirements-dev.txt
+  - pip install -e .
+
+script:
+  - pytest


### PR DESCRIPTION
This PR adds a `.travis.yml` file that Travis-CI (https://travis-ci.org/) understands and can use to run the test suite on every commit automatically.

In addition to this, you'll need to link your GitHub account to Travis-CI and then enable the repo at https://travis-ci.org/account/repositories